### PR TITLE
Minor clean-ups.

### DIFF
--- a/src/Text/DocTemplates/Parser.hs
+++ b/src/Text/DocTemplates/Parser.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE BangPatterns #-}
 {- |
    Module      : Text.DocTemplates.Parser
    Copyright   : Copyright (C) 2009-2019 John MacFarlane
@@ -140,10 +139,9 @@ pEscape = Literal "$" <$ P.try (P.string "$$" <* backupSourcePos 1)
 
 pDirective :: (TemplateTarget a, TemplateMonad m)
            => Parser m (Template a)
-pDirective = do
-  res <- pConditional <|> pForLoop <|> pReflowToggle <|> pNested <|>
-         pInterpolate <|> pBarePartial
-  return res
+pDirective =
+  pConditional <|> pForLoop <|> pReflowToggle <|> pNested <|>
+  pInterpolate <|> pBarePartial
 
 pEnclosed :: Monad m => Parser m a -> Parser m a
 pEnclosed parser = P.try $ do
@@ -227,7 +225,7 @@ pNested = do
           return (y <> z)
   let contents = x <> mconcat xs
   P.updateState $ \st -> st{ nestedCol = oldNested }
-  return $ Nested $ contents
+  return $ Nested contents
 
 pForLoop :: (TemplateTarget a, TemplateMonad m) => Parser m (Template a)
 pForLoop = do


### PR DESCRIPTION
I made some changes to the code while experimenting with overlapping instances. Perhaps you would like some of them. Here is what I did:

1. Delete unused pragmas.
2. Align the code indentation.
3. Remove redundant `$`.
4. Remove redundant `do`.
5. Use `fromMaybe`.
6. Remove redundant constraints in contexts.

By the way, I know the why `toContext String String` is needed, but let's discuss that in another PR.